### PR TITLE
 Limit HTTP proxy listen address + add real_ip_header config option

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -56,11 +56,12 @@ type CertificatesConfig struct {
 }
 
 type GeneralConfig struct {
-	Domain      string `mapstructure:"domain" json:"domain" yaml:"domain"`
-	Ipv4        string `mapstructure:"ipv4" json:"ipv4" yaml:"ipv4"`
-	RedirectUrl string `mapstructure:"redirect_url" json:"redirect_url" yaml:"redirect_url"`
-	HttpsPort   int    `mapstructure:"https_port" json:"https_port" yaml:"https_port"`
-	DnsPort     int    `mapstructure:"dns_port" json:"dns_port" yaml:"dns_port"`
+	Domain       string `mapstructure:"domain" json:"domain" yaml:"domain"`
+	Ipv4         string `mapstructure:"ipv4" json:"ipv4" yaml:"ipv4"`
+	RedirectUrl  string `mapstructure:"redirect_url" json:"redirect_url" yaml:"redirect_url"`
+	HttpsPort    int    `mapstructure:"https_port" json:"https_port" yaml:"https_port"`
+	DnsPort      int    `mapstructure:"dns_port" json:"dns_port" yaml:"dns_port"`
+	RealIpHeader string `mapstructure:"real_ip_header" json:"real_ip_header" yaml:"real_ip_header"`
 }
 
 type Config struct {
@@ -221,6 +222,13 @@ func (c *Config) SetDnsPort(port int) {
 	c.general.DnsPort = port
 	c.cfg.Set(CFG_GENERAL, c.general)
 	log.Info("dns port set to: %d", port)
+	c.cfg.WriteConfig()
+}
+
+func (c *Config) SetRealIpHeader(header_name string) {
+	c.general.RealIpHeader = header_name
+	c.cfg.Set(CFG_GENERAL, c.general)
+	log.Info("real IP header set to: %s", header_name)
 	c.cfg.WriteConfig()
 }
 
@@ -663,6 +671,10 @@ func (c *Config) GetHttpsPort() int {
 
 func (c *Config) GetDnsPort() int {
 	return c.general.DnsPort
+}
+
+func (c *Config) GetRealIpHeader() string {
+	return c.general.RealIpHeader
 }
 
 func (c *Config) GetRedirectorsDir() string {

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -181,8 +181,8 @@ func (t *Terminal) DoWork() {
 func (t *Terminal) handleConfig(args []string) error {
 	pn := len(args)
 	if pn == 0 {
-		keys := []string{"domain", "ipv4", "https_port", "dns_port", "redirect_url"}
-		vals := []string{t.cfg.general.Domain, t.cfg.general.Ipv4, strconv.Itoa(t.cfg.general.HttpsPort), strconv.Itoa(t.cfg.general.DnsPort), t.cfg.general.RedirectUrl}
+		keys := []string{"domain", "ipv4", "https_port", "dns_port", "real_ip_header", "redirect_url"}
+		vals := []string{t.cfg.general.Domain, t.cfg.general.Ipv4, strconv.Itoa(t.cfg.general.HttpsPort), strconv.Itoa(t.cfg.general.DnsPort), t.cfg.general.RealIpHeader, t.cfg.general.RedirectUrl}
 		log.Printf("\n%s\n", AsRows(keys, vals))
 		return nil
 	} else if pn == 2 {
@@ -194,6 +194,9 @@ func (t *Terminal) handleConfig(args []string) error {
 			return nil
 		case "ipv4":
 			t.cfg.SetServerIP(args[1])
+			return nil
+		case "real_ip_header":
+			t.cfg.SetRealIpHeader(args[1])
 			return nil
 		case "redirect_url":
 			if len(args[1]) > 0 {
@@ -1009,10 +1012,11 @@ func (t *Terminal) handleLures(args []string) error {
 func (t *Terminal) createHelp() {
 	h, _ := NewHelp()
 	h.AddCommand("config", "general", "manage general configuration", "Shows values of all configuration variables and allows to change them.", LAYER_TOP,
-		readline.PcItem("config", readline.PcItem("domain"), readline.PcItem("ipv4"), readline.PcItem("redirect_url")))
+		readline.PcItem("config", readline.PcItem("domain"), readline.PcItem("ipv4"), readline.PcItem("real_ip_header"), readline.PcItem("redirect_url")))
 	h.AddSubCommand("config", nil, "", "show all configuration variables")
 	h.AddSubCommand("config", []string{"domain"}, "domain <domain>", "set base domain for all phishlets (e.g. evilsite.com)")
 	h.AddSubCommand("config", []string{"ipv4"}, "ipv4 <ip_address>", "set ipv4 external address of the current server")
+	h.AddSubCommand("config", []string{"real_ip_header"}, "real_ip_header <name>", "if set, read client IP from this HTTP header instead from source address of the TCP connection (useful if Evilginx is behind a reverse proxy)")
 	h.AddSubCommand("config", []string{"redirect_url"}, "redirect_url <url>", "change the url where all unauthorized requests will be redirected to (phishing urls will need to be regenerated)")
 
 	h.AddCommand("proxy", "general", "manage proxy configuration", "Configures proxy which will be used to proxy the connection to remote website", LAYER_TOP,

--- a/main.go
+++ b/main.go
@@ -169,7 +169,7 @@ func main() {
 		return
 	}
 
-	hp, _ := core.NewHttpProxy("", cfg.GetHttpsPort(), cfg, crt_db, db, bl, *developer_mode)
+	hp, _ := core.NewHttpProxy(cfg.GetServerIP(), cfg.GetHttpsPort(), cfg, crt_db, db, bl, *developer_mode)
 	hp.Start()
 
 	t, err := core.NewTerminal(hp, cfg, crt_db, db, *developer_mode)


### PR DESCRIPTION
The HTTP proxy should respect IPv4 address set in configuration and not listen on 0.0.0.0 so it won't interfere with other daemons listening on the same port on different (specific) IP address.

When Evilginx is running behind a reverse HTTP proxy, the information on client IP address is lost. The client with IP address *A.A.A.A* connects to proxy at *B.B.B.B*, which then makes connection to Evilginx at *C.C.C.C*. The client IP address in Evilginx is determined from source address of the TCP connection and so *B.B.B.B* is logged and used in blacklist instead of *A.A.A.A*. The new config option `real_ip_header` adds possibility to read information on original client IP address from a specified HTTP header set by the reverse HTTP proxy (e.g. "*X-Forwarded-For*")
